### PR TITLE
Ldapauth2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,6 +120,22 @@
   revision = "2caba252f4dc53eaf6b553000885530023f54623"
 
 [[projects]]
+  digest = "1:af07c44dc04418be522bfd4e21ca9130d58169ea084e3a883e23772003a381c4"
+  name = "gopkg.in/asn1-ber.v1"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f715ec2f112d1e4195b827ad68cf44017a3ef2b1"
+  version = "v1.3"
+
+[[projects]]
+  digest = "1:dd1abec5df03edb5ee20a8ad37bc31688becaf939e94218427486b9472636bb9"
+  name = "gopkg.in/ldap.v3"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "214f299a0ecb2a6c6f6d2b0f13977032b207dc58"
+  version = "v3.0.1"
+
+[[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -141,6 +157,7 @@
     "github.com/lib/pq",
     "github.com/mitchellh/mapstructure",
     "github.com/stretchr/testify/assert",
+    "gopkg.in/ldap.v3",
     "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"

--- a/README.md
+++ b/README.md
@@ -33,16 +33,19 @@ The only option to be specified as a CLI arg is a  bare minimum config.toml will
 Specifying An alert_config containing at least one alert definition is optional.
 
 ```
-./alert_manager -logtostderr -config config.toml -schema schema.sql -alert_config alert_config.yaml
+./alert_manager -logtostderr -config config.toml -alert_config alert_config.yaml
 ```
 
 For verbose logging:
 ```
-./alert_manager -logtostderr -v=<level> -config config.toml -schema schema.sql -alert_config alert_config.yaml
+./alert_manager -logtostderr -v=<level> -config config.toml -alert_config alert_config.yaml
 ```
 
+## Deployment
+AM deployment supports teamviews. Different teams can deploy different instances of the alert manager backend and set the team name using the config setting (agent.TeamName). A common database and UI Deployment can be used organization wide. The team name is used to partition alerts and teamviews ensure that alerts belonging to a particular team can only be viewed/actioned by members of that team.
+
 ## Listeners
-Currently a generic webhook listener is supported that receives alerts from any sources capable of sending alert data to a webhook endpoint. The webhook listener has parsers defined for decoding the json body of the alert message received externally. Currently supported [parsers](./listener/parsers)  are Grafana, Observium and Kapacitor. New parsers can be easily added.
+Currently a generic webhook listener is supported that receives alerts from any sources capable of sending alert data to a webhook endpoint. The webhook listener has parsers defined for decoding the json body of the alert message received externally. There are parsers [parsers](./listener/parsers) supported for a few alerting sources. If your source supports custom json bodies, the generic json parser can be used. New parsers can be easily added.
 
 The format of the webhook url is:
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -2,6 +2,9 @@
 
 The v1 basic Rest API allows for querying the alert database using any of the available fields of an alert. It also allows common alert operations and creation and deletion of suppression rules.
 
+## Authentication
+All alert write actions require authentication. Currently, basic LDAP authentication is supported. Once a user is successfully authenticated, a Json Web Token(JWT) is sent back with successful auth response, along with the expiry time. In order to perform updates and actions, the client first needs to authenticate and obtain a JWT using the *api/auth* endpoint and use it as bearer authentication in subsequent PATCH requests. Once obtained, tokens have an expiry time (usually 24 hours). It is up to the client to refresh tokens using the *api/auth/refresh* endpoint within 30 seconds on token expiration.
+
 ## Queries
 
 Query all alerts or individual alerts:
@@ -46,8 +49,6 @@ http://<am_url>/api/alerts?limit=50&offset=50 ( alerts 51-100 )
 ```
 
 ## Alert updates and actions
-In order to perform updates and actions, the client first needs to obtain a JSON Web Token (JWT) using the *api/auth* endpoint and use it as bearer authentication in subsequent PATCH requests. Once obtained, a token does not expire and is valid for as long as the server does not restart again. 
-
 First send an auth request using the correct username and password:
 ```
 POST:

--- a/api/auth.go
+++ b/api/auth.go
@@ -51,8 +51,12 @@ func (l *LDAPAuth) Authenticate(username, password string) (bool, error) {
 		return false, fmt.Errorf("failed to connect to ldap: %v", err)
 	}
 	defer c.Close()
+	return l.doAuth(username, password, c)
+}
+
+func (l *LDAPAuth) doAuth(username, password string, c ldap.Client) (bool, error) {
 	if l.secure {
-		err = c.StartTLS(&tls.Config{InsecureSkipVerify: true})
+		err := c.StartTLS(&tls.Config{InsecureSkipVerify: true})
 		if err != nil {
 			return false, err
 		}

--- a/api/auth.go
+++ b/api/auth.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"crypto/tls"
+	"fmt"
+	"github.com/golang/glog"
+	"gopkg.in/ldap.v3"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const (
+	ldapBindUserEnv = "AM_LDAP_BIND_USER"
+	ldapBindPassEnv = "AM_LDAP_BIND_PASSWORD"
+)
+
+type LDAPAuth struct {
+	URL          string
+	BindDN       string
+	BaseDN       string
+	BindUser     string
+	BindPassword string
+	secure       bool
+}
+
+func NewLDAPAuth(uri, baseDN, bindDN, bindUser, bindPass string) (*LDAPAuth, error) {
+	if bindUser == "" || bindPass == "" {
+		bindUser = os.Getenv(ldapBindUserEnv)
+		bindPass = os.Getenv(ldapBindPassEnv)
+	}
+	if bindUser == "" || bindPass == "" {
+		return nil, fmt.Errorf("Unable to get ldap bind credentials")
+	}
+	l := &LDAPAuth{BindDN: bindDN, BaseDN: baseDN, BindUser: bindUser, BindPassword: bindPass}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "ldaps" {
+		l.secure = true
+	}
+	l.URL = u.Host
+	return l, nil
+}
+
+func (l *LDAPAuth) Authenticate(username, password string) (bool, error) {
+	// connect to ldap server
+	c, err := ldap.Dial("tcp", l.URL)
+	if err != nil {
+		return false, fmt.Errorf("failed to connect to ldap: %v", err)
+	}
+	defer c.Close()
+	if l.secure {
+		err = c.StartTLS(&tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return false, err
+		}
+	}
+	bindDN := strings.Join([]string{fmt.Sprintf("CN=%s", l.BindUser), l.BindDN}, ",")
+	// try bind to ldap server
+	if err := c.Bind(bindDN, l.BindPassword); err != nil {
+		return false, fmt.Errorf("Failed to bind: %v", err)
+	}
+	// Search for the given username
+	searchRequest := ldap.NewSearchRequest(
+		l.BaseDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		fmt.Sprintf("(&(objectCategory=person)(objectClass=user)(sAMAccountName=%s))", username),
+		[]string{"dn"},
+		nil,
+	)
+	sr, err := c.Search(searchRequest)
+	if err != nil {
+		return false, err
+	}
+	if len(sr.Entries) != 1 {
+		return false, fmt.Errorf("User does not exist or too many entries returned")
+	}
+	userdn := sr.Entries[0].DN
+	// Bind as the user to verify their password
+	err = c.Bind(userdn, password)
+	if err != nil {
+		glog.Errorf("User Authentication failed for %s", username)
+		return false, nil
+	}
+	return true, nil
+}

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/ldap.v3"
+	"testing"
+)
+
+type MockClient struct {
+	ldap.Client
+}
+
+func (c *MockClient) Bind(dn, password string) error {
+	if password == "fail" {
+		return fmt.Errorf("Failed !")
+	}
+	return nil
+}
+
+func (c *MockClient) Search(r *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	if r.BaseDN == "DC=foo,DC=bar" {
+		return &ldap.SearchResult{}, nil
+	}
+	return &ldap.SearchResult{
+		Entries: []*ldap.Entry{&ldap.Entry{DN: "DC=foo, DC=baz"}},
+	}, nil
+}
+
+func TestLDAPAuth(t *testing.T) {
+	auth, _ := NewLDAPAuth("uri", "baseDN", "bindDN", "user", "fail")
+	client := &MockClient{}
+	// test bind failure
+	res, err := auth.doAuth("foo", "bar", client)
+	assert.Equal(t, res, false)
+	assert.NotNil(t, err)
+	// test no entries
+	auth, _ = NewLDAPAuth("uri", "DC=foo,DC=bar", "bindDN", "user", "pass")
+	res, err = auth.doAuth("foo", "bar", client)
+	assert.Equal(t, res, false)
+	assert.NotNil(t, err)
+	// test auth failure
+	auth, _ = NewLDAPAuth("uri", "baseDN", "bindDN", "user", "pass")
+	res, err = auth.doAuth("foo", "fail", client)
+	assert.Equal(t, res, false)
+	assert.Nil(t, err)
+	// test auth success
+	res, err = auth.doAuth("foo", "bar", client)
+	assert.Equal(t, res, true)
+	assert.Nil(t, err)
+}

--- a/config.go
+++ b/config.go
@@ -11,9 +11,19 @@ import (
 )
 
 type AgentConfig struct {
-	ApiAddr             string        `mapstructure:"api_addr"`
 	StatsExportInterval time.Duration `mapstructure:"stats_export_interval"`
 	TeamName            string        `mapstructure:"team_name"`
+}
+
+type ApiConfig struct {
+	ApiAddr      string `mapstructure:"api_addr"`
+	ApiKey       string `mapstructure:"api_key"`
+	AuthProvider string `mapstructure:"auth_provider"`
+	LdapUri      string `mapstructure:"ldap_uri"`
+	LdapBindDN   string `mapstructure:"ldap_binddn"`
+	LdapBaseDN   string `mapstructure:"ldap_basedn"`
+	LdapBinduser string `mapstructure:"ldap_binduser"`
+	LdapBindpass string `mapstructure:"ldap_bindpass"`
 }
 
 type DbConfig struct {
@@ -24,6 +34,7 @@ type DbConfig struct {
 
 type Config struct {
 	Agent    *AgentConfig
+	Api      *ApiConfig
 	Db       *DbConfig
 	Reporter *reporting.InfluxReporter
 }
@@ -42,6 +53,14 @@ func (c *Config) UnmarshalTOML(data interface{}) error {
 				return err
 			}
 			c.Agent = a
+		case "api":
+			a := &ApiConfig{}
+			decoderConfig.Result = a
+			decoder, _ := mapstructure.NewDecoder(decoderConfig)
+			if err := decoder.Decode(v); err != nil {
+				return err
+			}
+			c.Api = a
 		case "db":
 			d := &DbConfig{}
 			decoderConfig.Result = d

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -1,0 +1,67 @@
+[agent]
+  stats_export_interval = "120s"
+  # Team name is required to enable teamview support.
+  team_name = "myTeam"
+
+[api]
+  # api listen addr
+  api_addr = ":8181"
+  # api key is used to generate tokens and needs to be unique per instane
+  api_key = "my_secret_key"
+  # if auth provider is not specified, then authentication is disabled
+  auth_provider = "ldap"
+  # ldap specific config
+  ldap_uri = "ldap://ldap.com"
+  ldap_binddn = "ldap_binddn"
+  ldap_basedn = "ldap_basedn"
+  ldap_binduser = "bind_user"
+  ldap_bindpass = "bind_pass"
+
+[db]
+  # db listen addr
+  addr = ":5432"
+  username = "alert_manager"
+  password = "alert_manager"
+  ## database name to use - needs to be present already
+  db_name = "alert_manager"
+  # connect timeout in seconds
+  timeout = 5
+
+[reporter]
+  # influxdb address to send stats. "stdout" will print to screen
+  url = "stdout"
+  flush_interval = "10s"
+
+[listeners.webhook]
+  # webhook listen addr
+  listen_addr = ":8282"
+  ## Enable http basic auth for webhook listener
+  use_auth = false
+  ## username, password for http basic auth
+  username = ""
+  password = ""
+
+
+[transforms.mytransform]
+  # transform related settings here
+
+[outputs.influx]
+  # measurement name for influxdb reporting
+  measurement = "alert_manager_alerts"
+
+[outputs.slack]
+  url = "slack_url"
+  recipient = "#alerts"
+  upload = false
+  token = ""
+
+[outputs.email]
+  smtp_addr = "smtp.foo:"
+  smtp_username = ""
+  smtp_password = ""
+  from = "alert_manager@am.com"
+  recipients = ["noc@org.com"]
+
+[outputs.victorops]
+  url = "https://victorops url"
+  auto_resolve = true


### PR DESCRIPTION
adds basic ldap authentication and token expiry. Token will now expiry in 24 hour and needs to be refreshed 30 seconds before expiry by the client.