### PR TITLE
Dont auto-clear ack'd alerts

### DIFF
--- a/alert_config.yaml
+++ b/alert_config.yaml
@@ -38,6 +38,8 @@ alert_config:
       auto_clear: false
       # notify on clear (default : False)
       notify_on_clear: true
+      # configures whether to auto-clear the alert if it has been acknowledged
+      clear_acknowledged: true
       # set of per-severity outputs to send the alert notification to
       outputs:
         - matches:

--- a/handler/config.go
+++ b/handler/config.go
@@ -36,22 +36,23 @@ type TeamConfig struct {
 type AlertConfig struct {
 	Name   string
 	Config struct {
-		Scope            string
-		Severity         string
-		Tags             []string
-		Description      string
-		Source           string
-		AutoExpire       *bool         `yaml:"auto_expire"`
-		ExpireAfter      time.Duration `yaml:"expire_after"`
-		AutoClear        *bool         `yaml:"auto_clear"`
-		NotifyOnClear    bool          `yaml:"notify_on_clear"`
-		NotifyDelay      time.Duration `yaml:"notify_delay"`
-		NotifyRemind     time.Duration `yaml:"notify_remind"`
-		DisableNotify    bool          `yaml:"disable_notify"`
-		Outputs          Outputs
-		StaticLabels     map[string]interface{} `yaml:"static_labels"`
-		AggregationRules []string               `yaml:"aggregation_rules"`
-		EscalationRules  []struct {
+		Scope             string
+		Severity          string
+		Tags              []string
+		Description       string
+		Source            string
+		AutoExpire        *bool         `yaml:"auto_expire"`
+		ExpireAfter       time.Duration `yaml:"expire_after"`
+		AutoClear         *bool         `yaml:"auto_clear"`
+		NotifyOnClear     bool          `yaml:"notify_on_clear"`
+		NotifyDelay       time.Duration `yaml:"notify_delay"`
+		NotifyRemind      time.Duration `yaml:"notify_remind"`
+		DisableNotify     bool          `yaml:"disable_notify"`
+		ClearAcknowledged bool          `yaml:"clear_acknowledged"`
+		Outputs           Outputs
+		StaticLabels      map[string]interface{} `yaml:"static_labels"`
+		AggregationRules  []string               `yaml:"aggregation_rules"`
+		EscalationRules   []struct {
 			After      time.Duration
 			EscalateTo string `yaml:"escalate_to"`
 		} `yaml:"escalation_rules"`

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -206,7 +206,7 @@ func (h *AlertHandler) handleClear(ctx context.Context, tx models.Txn, alert *mo
 		return nil
 	}
 	// dont clear acknowledged alerts
-	if existingAlert.Owner.Valid {
+	if config, ok := Config.GetAlertConfig(existingAlert.Name); ok && config.Config.ClearAcknowledged && existingAlert.Owner.Valid {
 		glog.V(4).Infof("Not clearing ack'd alert: %d", existingAlert.Id)
 		return nil
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -205,6 +205,11 @@ func (h *AlertHandler) handleClear(ctx context.Context, tx models.Txn, alert *mo
 		glog.V(2).Infof("Not auto-clearing alert %d ", existingAlert.Id)
 		return nil
 	}
+	// dont clear acknowledged alerts
+	if existingAlert.Owner.Valid {
+		glog.V(4).Infof("Not clearing ack'd alert: %d", existingAlert.Id)
+		return nil
+	}
 	// wait for a holddown period before clearing the alert to avoid flaps
 	if holddown == 0 {
 		return h.clearAlert(ctx, tx, existingAlert)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -248,6 +248,12 @@ func TestHandlerAlertClear(t *testing.T) {
 	event := <-h.procChan
 	assert.Equal(t, event.Type, models.EventType_CLEARED)
 	assert.Equal(t, int(event.Alert.Id), 100)
+
+	// test alert clear - ack'd
+	mockAlerts["existing_a3"].AutoClear = true
+	mockAlerts["existing_a3"].Owner.Valid = true
+	h.handleClear(ctx, tx, mockAlerts["existing_a3"], 0)
+	assert.Equal(t, mockAlerts["existing_a3"].Status.String(), "ACTIVE")
 }
 
 func TestHandlerAlertExpiry(t *testing.T) {

--- a/testutil/testdata/test_config.yaml
+++ b/testutil/testdata/test_config.yaml
@@ -33,6 +33,10 @@ alert_config:
             severity: CRITICAL
           send_to: [ slack.test1 ]
 
+  - name: Test Alert 3
+    config:
+      clear_acknowledged: true
+
   - name: Neteng BGP Down
     config:
       scope: bgp_peer


### PR DESCRIPTION
current behavior is to auto-clear all alerts if autoclear = true. This provides a config option that so that if an alert is acknowledged, it wont be cleared until manually cleared  