### PR TITLE
Correcting the A/Z side agg alerts to display both lag & phys interfaces

### DIFF
--- a/plugins/processors/aggregator/groupers/fibercut.go
+++ b/plugins/processors/aggregator/groupers/fibercut.go
@@ -35,21 +35,19 @@ func (g fibercutGrouper) Name() string {
 
 func (g fibercutGrouper) AggDesc(alerts []*models.Alert) string {
 
-	type AlertInfo struct {
-		provider, aSideDev, aSideInt, zSideDev, zSideInt string
-	}
-	m := make(map[string]AlertInfo)
+	// Map to keep track of alerts that are triggered on both ends of the same circuit ID. Map value is not used.
+	// The key is a string with the cktId concatenated with Aside interface name.
+	m := make(map[string]bool)
 
 	msg := "Affected Interfaces:\n"
 	for _, a := range alerts {
-		if _, ok := m[a.Labels["cktId"].(string)]; !ok {
-			m[a.Labels["cktId"].(string)] = AlertInfo{a.Labels["provider"].(string), a.Labels["aSideDeviceName"].(string), a.Labels["aSideInterface"].(string),
-				a.Labels["zSideDeviceName"].(string), a.Labels["zSideInterface"].(string)}
-		}
-	}
 
-	for k, v := range m {
-		msg += fmt.Sprintf("Provider: %s, CktId: %s, A-Side: %s:%s, Z-Side: %s:%s\n", v.provider, k, v.aSideDev, v.aSideInt, v.zSideDev, v.zSideInt)
+		if _, ok := m[a.Labels["cktId"].(string)+a.Labels["aSideInterface"].(string)]; !ok {
+			m[a.Labels["cktId"].(string)+a.Labels["aSideInterface"].(string)] = true
+			msg += fmt.Sprintf("Provider: %s, CktId: %s, A-Side: %s:%s, Z-Side: %s:%s\n",
+				a.Labels["provider"].(string), a.Labels["cktId"].(string), a.Labels["aSideDeviceName"].(string),
+				a.Labels["aSideInterface"].(string), a.Labels["zSideDeviceName"].(string), a.Labels["zSideInterface"].(string))
+		}
 	}
 	return msg
 }


### PR DESCRIPTION
Tested with manual alerts

`alert_manager=# select description from alerts ;
                                                                     description
-----------------------------------------------------------------------------------------------------------------------------------------------------
 Affected Interfaces:                                                                                                                               +
 Provider: gtt, CktId: RBLX-000197-1, A-Side: br2-ams1:et-0/0/15:3, Z-Side: br2-fra1:et-0/0/4:2                                                     +
 Provider: gtt, CktId: RBLX-000107-1, A-Side: br2-lhr1:et-0/0/15:0, Z-Side: br2-fra1:et-0/0/15:0                                                    +

 ALERT: [br2-fra1.roblox.net] [port] [et-0/0/4:2] Neteng BB Link Down / et-0/0/15:3.br2-ams1|T=bb|P=gtt|I=RBLX-000197-1|V=01093843|R=br|E=ae5|S=10G
 ALERT: [br2-lhr1.roblox.net] [port] [et-0/0/15:0] Neteng BB Link Down / et-0/0/15:0.br2-fra1|T=bb|P=gtt|I=RBLX-000107-1|V=00924357|R=br|E=ae3|S=10G
 ALERT: [br2-fra1.roblox.net] [port] [et-0/0/15:0] Neteng BB Link Down / et-0/0/15:0.br2-lhr1|T=bb|P=gtt|I=RBLX-000107-1|V=00924357|R=br|E=ae3|S=10G
 ALERT: [br2-ams1.roblox.net] [port] [et-0/0/15:3] Neteng BB Link Down / et-0/0/4:2.br2-fra1|T=bb|P=gtt|I=RBLX-000197-1|V=01093843|R=br|E=ae4|S=10G
(5 rows)`