### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.12-alpine as builder
 
 ENV GO111MODULE=on
 


### PR DESCRIPTION
pin to 1.12 as something changed in 1.13 that is breaking builds