### PR TITLE
Add alert dedup logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 alert_manager
 .vscode/
+ui/Makefile

--- a/alert_manager.go
+++ b/alert_manager.go
@@ -42,7 +42,7 @@ func Run(config *Config) {
 	}()
 
 	// start the handler
-	handler := ah.NewHandler(db, config.Agent.ClearHolddownInterval)
+	handler := ah.NewHandler(db)
 	go handler.Start(ctx)
 
 	//Initialize all the plugins

--- a/config.go
+++ b/config.go
@@ -12,9 +12,8 @@ import (
 )
 
 type AgentConfig struct {
-	StatsExportInterval   time.Duration `mapstructure:"stats_export_interval"`
-	ClearHolddownInterval time.Duration `mapstructure:"clear_holddown_interval"`
-	WebUrl                string        `mapstructure:"web_url"`
+	StatsExportInterval time.Duration `mapstructure:"stats_export_interval"`
+	WebUrl              string        `mapstructure:"web_url"`
 }
 
 type ApiConfig struct {

--- a/handler/config.go
+++ b/handler/config.go
@@ -36,23 +36,23 @@ type TeamConfig struct {
 type AlertConfig struct {
 	Name   string
 	Config struct {
-		Scope             string
-		Severity          string
-		Tags              []string
-		Description       string
-		Source            string
-		AutoExpire        *bool         `yaml:"auto_expire"`
-		ExpireAfter       time.Duration `yaml:"expire_after"`
-		AutoClear         *bool         `yaml:"auto_clear"`
-		NotifyOnClear     bool          `yaml:"notify_on_clear"`
-		NotifyDelay       time.Duration `yaml:"notify_delay"`
-		NotifyRemind      time.Duration `yaml:"notify_remind"`
-		DisableNotify     bool          `yaml:"disable_notify"`
-		ClearAcknowledged bool          `yaml:"clear_acknowledged"`
-		Outputs           Outputs
-		StaticLabels      map[string]interface{} `yaml:"static_labels"`
-		AggregationRules  []string               `yaml:"aggregation_rules"`
-		EscalationRules   []struct {
+		Scope                 string
+		Severity              string
+		Tags                  []string
+		Description           string
+		Source                string
+		AutoExpire            *bool         `yaml:"auto_expire"`
+		ExpireAfter           time.Duration `yaml:"expire_after"`
+		AutoClear             *bool         `yaml:"auto_clear"`
+		NotifyOnClear         bool          `yaml:"notify_on_clear"`
+		NotifyDelay           time.Duration `yaml:"notify_delay"`
+		NotifyRemind          time.Duration `yaml:"notify_remind"`
+		DisableNotify         bool          `yaml:"disable_notify"`
+		DontClearAcknowledged bool          `yaml:"dont_clear_acknowledged"`
+		Outputs               Outputs
+		StaticLabels          map[string]interface{} `yaml:"static_labels"`
+		AggregationRules      []string               `yaml:"aggregation_rules"`
+		EscalationRules       []struct {
 			After      time.Duration
 			EscalateTo string `yaml:"escalate_to"`
 		} `yaml:"escalation_rules"`

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -235,6 +235,10 @@ func (h *AlertHandler) reactivateAlert(tx models.Txn, existingAlert *models.Aler
 	if err := tx.InQuery(models.QueryUpdateManyStatus, models.Status_ACTIVE, toUpdate); err != nil {
 		return fmt.Errorf("Failed to update alert status: %v", err)
 	}
+	tx.NewRecord(existingAlert.Id, "Alert re-activated")
+	if existingAlert.AggregatorId != 0 {
+		tx.NewRecord(existingAlert.AggregatorId, fmt.Sprintf("Alert re-activated due to component alert %d", existingAlert.Id))
+	}
 	return nil
 }
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -22,55 +21,24 @@ const (
 // all listeners send alerts down this channel
 var ListenChan = make(chan *models.AlertEvent)
 
-// ClearHandler keeps a track of clearing active alerts
-type ClearHandler struct {
-	actives map[int64]chan struct{}
-	sync.RWMutex
-}
-
-func (c *ClearHandler) get(id int64) (chan struct{}, bool) {
-	c.RLock()
-	defer c.RUnlock()
-	resetClear, ok := c.actives[id]
-	return resetClear, ok
-}
-
-func (c *ClearHandler) add(id int64) chan struct{} {
-	c.Lock()
-	defer c.Unlock()
-	c.actives[id] = make(chan struct{})
-	return c.actives[id]
-}
-
-func (c *ClearHandler) delete(id int64) {
-	c.Lock()
-	defer c.Unlock()
-	delete(c.actives, id)
-}
-
 // AlertHandler handles common alert operations such as expiry, suppression etc.
 // It also sends alerts to interested receivers
 type AlertHandler struct {
 	// db handler
-	Db            models.Dbase
-	Suppressor    *suppressor
-	Teams         models.Teams
-	procChan      chan *models.AlertEvent
-	clearer       *ClearHandler
-	clearHolddown time.Duration
-
+	Db                 models.Dbase
+	Suppressor         *suppressor
+	Teams              models.Teams
+	procChan           chan *models.AlertEvent
 	statTransformError stats.Stat
 	statDbError        stats.Stat
 }
 
 // NewHandler returns a new alert handler which uses the supplied db
-func NewHandler(db models.Dbase, clearHolddown time.Duration) *AlertHandler {
+func NewHandler(db models.Dbase) *AlertHandler {
 	h := &AlertHandler{
 		Db:                 db,
 		Suppressor:         GetSuppressor(db),
 		procChan:           make(chan *models.AlertEvent),
-		clearer:            &ClearHandler{actives: make(map[int64]chan struct{})},
-		clearHolddown:      clearHolddown,
 		statTransformError: stats.NewCounter("handler.transform_errors"),
 		statDbError:        stats.NewCounter("handler.db_errors"),
 	}
@@ -134,7 +102,7 @@ func (h *AlertHandler) Start(ctx context.Context) {
 				case models.EventType_ACTIVE:
 					return h.handleActive(ctx, tx, alert)
 				case models.EventType_CLEARED:
-					return h.handleClear(ctx, tx, alert, h.clearHolddown)
+					return h.handleClear(ctx, tx, alert)
 				}
 				return nil
 			})
@@ -151,20 +119,24 @@ func (h *AlertHandler) Start(ctx context.Context) {
 }
 
 func (h *AlertHandler) handleActive(ctx context.Context, tx models.Txn, alert *models.Alert) error {
-	if h.checkExisting(tx, alert) {
-		return nil
+	var labels models.Labels
+	existingAlert, err := h.GetExisting(tx, alert)
+	if err != nil {
+		glog.V(2).Infof("No existing alert found for %s:%s:%s", alert.Name, alert.Device.String, alert.Entity)
+		// add transforms
+		h.applyTransforms(alert)
+		alert.ExtendLabels()
+		labels = alert.Labels
+	} else {
+		labels = existingAlert.Labels
 	}
-	// add transforms
-	h.applyTransforms(alert)
-
 	// check if alert matches an existing suppression rule based on alert labels
-	alert.ExtendLabels()
-	if rule := h.Suppressor.Match(alert.Labels); rule != nil && rule.TimeLeft() > 0 {
+	if rule := h.Suppressor.Match(labels); rule != nil && rule.TimeLeft() > 0 {
 		glog.V(2).Infof("Found matching suppression rule for %s:%s:%s: %d:%s", alert.Name, alert.Entity, alert.Device.String, rule.Id, rule.Name)
 		return nil
 	}
-	if h.checkAggregated(tx, alert) {
-		return nil
+	if existingAlert != nil {
+		return h.reactivateAlert(tx, existingAlert)
 	}
 	// new alert
 	if !h.Teams.Contains(alert.Team) {
@@ -194,50 +166,27 @@ func (h *AlertHandler) handleActive(ctx context.Context, tx models.Txn, alert *m
 	return nil
 }
 
-func (h *AlertHandler) handleClear(ctx context.Context, tx models.Txn, alert *models.Alert, holddown time.Duration) error {
+func (h *AlertHandler) handleClear(ctx context.Context, tx models.Txn, alert *models.Alert) error {
 	// clear existing alert if auto clear is true
 	existingAlert, err := h.GetExisting(tx, alert)
 	if err != nil {
 		glog.V(2).Infof("No existing alert found for %s:%s to clear", alert.Name, alert.Entity)
 		return nil
 	}
+	if existingAlert.Status == models.Status_CLEARED {
+		// already cleared
+		return nil
+	}
 	if !existingAlert.AutoClear {
 		glog.V(2).Infof("Not auto-clearing alert %d ", existingAlert.Id)
 		return nil
 	}
-	// dont clear acknowledged alerts
-	if config, ok := Config.GetAlertConfig(existingAlert.Name); ok && config.Config.ClearAcknowledged && existingAlert.Owner.Valid {
+	// dont clear acknowledged alerts if the config says so
+	if config, ok := Config.GetAlertConfig(existingAlert.Name); ok && config.Config.DontClearAcknowledged && existingAlert.Owner.Valid {
 		glog.V(4).Infof("Not clearing ack'd alert: %d", existingAlert.Id)
 		return nil
 	}
-	// wait for a holddown period before clearing the alert to avoid flaps
-	if holddown == 0 {
-		return h.clearAlert(ctx, tx, existingAlert)
-	}
-	go func() {
-		if _, ok := h.clearer.get(existingAlert.Id); ok {
-			return
-		}
-		t := time.NewTimer(holddown)
-		resetClear := h.clearer.add(existingAlert.Id)
-		defer h.clearer.delete(existingAlert.Id)
-		for {
-			select {
-			case <-t.C:
-				newTx := h.Db.NewTx()
-				err := models.WithTx(ctx, newTx, func(ctx context.Context, tx models.Txn) error {
-					return h.clearAlert(ctx, tx, existingAlert)
-				})
-				if err != nil {
-					glog.Error(err)
-				}
-				return
-			case <-resetClear:
-				return
-			}
-		}
-	}()
-	return nil
+	return h.clearAlert(ctx, tx, existingAlert)
 }
 
 func (h *AlertHandler) clearAlert(ctx context.Context, tx models.Txn, alert *models.Alert) error {
@@ -249,58 +198,44 @@ func (h *AlertHandler) clearAlert(ctx context.Context, tx models.Txn, alert *mod
 	return nil
 }
 
-func (h *AlertHandler) checkExisting(tx models.Txn, alert *models.Alert) bool {
-	existingAlert, err := h.GetExisting(tx, alert)
-	if err != nil {
-		glog.V(2).Infof("No existing alert found for %s:%s", alert.Name, alert.Entity)
-		return false
+func (h *AlertHandler) GetExisting(tx models.Txn, alert *models.Alert) (*models.Alert, error) {
+	var existing *models.Alert
+	var err error
+	// an alert is assumed to be uniquely identified by its Id or by its Name:Device:Entity
+	if alert.Id > 0 {
+		existing, err = tx.GetAlert(models.QuerySelectById, alert.Id)
+	} else {
+		if alert.Device.Valid {
+			existing, err = tx.GetAlert(models.QuerySelectByDevice, alert.Name, alert.Entity, alert.Device.String)
+		} else {
+			existing, err = tx.GetAlert(models.QuerySelectByNameEntity, alert.Name, alert.Entity)
+		}
 	}
-	// extend the expiry time if alert already exists
+	if err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
+func (h *AlertHandler) reactivateAlert(tx models.Txn, existingAlert *models.Alert) error {
+	// reactivate the alert and the agg alert if applicable and extend the expiry time if alert already exists
 	toUpdate := []int64{existingAlert.Id}
 	if existingAlert.AggregatorId != 0 {
 		toUpdate = append(toUpdate, existingAlert.AggregatorId)
 	}
 	newLastActive := models.MyTime{time.Now()}
-	existingAlert.LastActive = newLastActive
-	err = tx.InQuery(models.QueryUpdateLastActive, newLastActive, toUpdate)
-	if err != nil {
+	if err := tx.InQuery(models.QueryUpdateLastActive, newLastActive, toUpdate); err != nil {
 		h.statDbError.Add(1)
-		glog.Errorf("Failed update last active: %v", err)
+		return fmt.Errorf("Failed update last active: %v", err)
 	}
-	if resetClear, ok := h.clearer.get(existingAlert.Id); ok {
-		resetClear <- struct{}{}
+	if existingAlert.Status == models.Status_ACTIVE || existingAlert.Status == models.Status_SUPPRESSED {
+		return nil
 	}
-	return err == nil
-}
-
-func (h *AlertHandler) checkAggregated(tx models.Txn, alert *models.Alert) bool {
-	var dev string
-	if alert.Device.Valid {
-		dev = alert.Device.String
+	glog.V(4).Infof("Reactivating old alert %d", existingAlert.Id)
+	if err := tx.InQuery(models.QueryUpdateManyStatus, models.Status_ACTIVE, toUpdate); err != nil {
+		return fmt.Errorf("Failed to update alert status: %v", err)
 	}
-	existing, err := tx.GetAlert(models.QuerySelectExistingAgg, alert.Name, alert.Entity, dev)
-	if err != nil {
-		glog.V(4).Infof("No existing alert found")
-		return false
-	}
-	existingAgg, err := tx.GetAlert(models.QuerySelectById, existing.AggregatorId)
-	if err != nil {
-		glog.V(4).Infof("No existing aggregate alert found")
-		return false
-	}
-	if existingAgg.Status != models.Status_ACTIVE {
-		return false
-	}
-	// ignore the new alert since it was previously aggregated and the agg is still active
-	alert.Status = models.Status_SUPPRESSED
-	existing.Status = models.Status_ACTIVE
-	existing.LastActive = models.MyTime{time.Now()}
-	if err = tx.UpdateAlert(existing); err != nil {
-		glog.Errorf("Unable to update alert: %v", err)
-		return false
-	}
-	glog.Infof("Found existing aggregated alert for %s: %d", existing.Name, existing.Id)
-	return true
+	return nil
 }
 
 func (h *AlertHandler) applyTransforms(alert *models.Alert) {
@@ -413,25 +348,6 @@ func (h *AlertHandler) handleEscalation(ctx context.Context) {
 		glog.Errorf("Failed to escalate alerts : %v", err)
 		h.statDbError.Add(1)
 	}
-}
-
-func (h *AlertHandler) GetExisting(tx models.Txn, alert *models.Alert) (*models.Alert, error) {
-	var existing *models.Alert
-	var err error
-	// an alert is assumed to be uniquely identified by its Id or by its Name:Device:Entity
-	if alert.Id > 0 {
-		existing, err = tx.GetAlert(models.QuerySelectById, alert.Id)
-	} else {
-		if alert.Device.Valid {
-			existing, err = tx.GetAlert(models.QuerySelectByDevice, alert.Name, alert.Entity, alert.Device.String)
-		} else {
-			existing, err = tx.GetAlert(models.QuerySelectByNameEntity, alert.Name, alert.Entity)
-		}
-	}
-	if err != nil {
-		return nil, err
-	}
-	return existing, nil
 }
 
 func (h *AlertHandler) Suppress(

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -37,6 +37,7 @@ func (m *MockDb) Close() error {
 
 type MockTx struct {
 	*models.Tx
+	inQuery func() error
 }
 
 func (t *MockTx) NewInsert(query string, item interface{}) (int64, error) {
@@ -72,10 +73,7 @@ func (t *MockTx) GetAlert(query string, args ...interface{}) (*models.Alert, err
 	case string:
 		for _, a := range mockAlerts {
 			if args[0].(string) == a.Name {
-				if query == models.QuerySelectByDevice && a.Status == models.Status_ACTIVE {
-					return a, nil
-				}
-				if query == models.QuerySelectExistingAgg {
+				if query == models.QuerySelectByDevice {
 					return a, nil
 				}
 			}
@@ -91,18 +89,10 @@ func (t *MockTx) GetAlert(query string, args ...interface{}) (*models.Alert, err
 }
 
 func (t *MockTx) InQuery(query string, args ...interface{}) error {
-	alertIDs := args[1].([]int64)
-	var alert *models.Alert
-	switch alertIDs[0] {
-	case 100:
-		alert = mockAlerts["existing_a1"]
-	case 200:
-		alert = mockAlerts["existing_a2"]
+	if t.inQuery != nil {
+		return t.inQuery()
 	}
-	if alert != nil {
-		alert.LastActive = nowTime
-	}
-	return nil
+	return fmt.Errorf("InQuery undefined")
 }
 
 func (t *MockTx) InSelect(query string, to interface{}, arg ...interface{}) error {
@@ -168,7 +158,6 @@ func NewTestHandler(procChanSize int) *AlertHandler {
 	m := &MockDb{}
 	h := &AlertHandler{Db: m, statTransformError: &tu.MockStat{}, statDbError: &tu.MockStat{}}
 	h.procChan = make(chan *models.AlertEvent, procChanSize)
-	h.clearer = &ClearHandler{actives: make(map[int64]chan struct{})}
 	h.Suppressor = &suppressor{db: m}
 	return h
 }
@@ -196,6 +185,10 @@ func TestHandlerAlertActive(t *testing.T) {
 	assert.Equal(t, h.Teams.Contains("t2"), true)
 
 	// test existing active alert
+	tx.(*MockTx).inQuery = func() error {
+		mockAlerts["existing_a1"].LastActive = nowTime
+		return nil
+	}
 	a1 := tu.MockAlert(0, "Test Alert 1", "", "d1", "e1", "src1", "scp1", "t1", "1", "WARN", []string{"a", "b"}, nil)
 	h.handleActive(ctx, tx, a1)
 	assert.Equal(t, int(a1.Id), 0)
@@ -215,22 +208,32 @@ func TestHandlerAlertActive(t *testing.T) {
 	a4.ExtendLabels()
 	assert.NotNil(t, h.Suppressor.Match(a4.Labels))
 
-	// test existing active agg
+	//// test a de-dedup of a cleared alert
+	tx.(*MockTx).inQuery = func() error {
+		mockAlerts["existing_a5"].Status = models.Status_ACTIVE
+		mockAlerts["existing_a6_agg"].Status = models.Status_ACTIVE
+		mockAlerts["existing_a5"].LastActive = nowTime
+		mockAlerts["existing_a6_agg"].LastActive = nowTime
+		return nil
+	}
 	new = tu.MockAlert(0, "Test Alert 5", "", "d5", "e5", "src5", "scp5", "t1", "5", "WARN", []string{"g", "h"}, nil)
 	mockAlerts["existing_a5"].Status = models.Status_CLEARED
+	mockAlerts["existing_a6_agg"].Status = models.Status_CLEARED
 	mockAlerts["existing_a5"].AggregatorId = 600
 	h.handleActive(ctx, tx, new)
-	assert.Equal(t, new.Status, models.Status_SUPPRESSED)
 	assert.Equal(t, mockAlerts["existing_a5"].Status, models.Status_ACTIVE)
+	assert.Equal(t, mockAlerts["existing_a5"].LastActive, nowTime)
+	assert.Equal(t, mockAlerts["existing_a6_agg"].Status, models.Status_ACTIVE)
+	assert.Equal(t, mockAlerts["existing_a6_agg"].LastActive, nowTime)
 	// test existing inactive agg
-	new.Status = models.Status_ACTIVE
-	mockAlerts["existing_a5"].Status = models.Status_CLEARED
-	mockAlerts["existing_a6_agg"].Status = models.Status_CLEARED
-	h.handleActive(ctx, tx, new)
-	assert.Equal(t, int(new.Id), 999)
-	event = <-h.procChan
-	assert.Equal(t, event.Type, models.EventType_ACTIVE)
-	assert.Equal(t, int(event.Alert.Id), 999)
+	//new.Status = models.Status_ACTIVE
+	//mockAlerts["existing_a5"].Status = models.Status_CLEARED
+	//mockAlerts["existing_a6_agg"].Status = models.Status_CLEARED
+	//h.handleActive(ctx, tx, new)
+	//assert.Equal(t, int(new.Id), 999)
+	//event = <-h.procChan
+	//assert.Equal(t, event.Type, models.EventType_ACTIVE)
+	//assert.Equal(t, int(event.Alert.Id), 999)
 }
 
 func TestHandlerAlertClear(t *testing.T) {
@@ -240,17 +243,17 @@ func TestHandlerAlertClear(t *testing.T) {
 
 	// test alert clear -non existing
 	a2 := tu.MockAlert(0, "Test Alert 2", "", "d2", "e2", "src2", "scp2", "t1", "2", "WARN", []string{"c", "d"}, nil)
-	h.handleClear(ctx, tx, a2, 0)
+	h.handleClear(ctx, tx, a2)
 	assert.Equal(t, a2.Status.String(), "ACTIVE")
 
 	// test alert clear - no autoclear
 	a1 := tu.MockAlert(0, "Test Alert 1", "", "d1", "e1", "src1", "scp1", "t1", "1", "WARN", []string{"a", "b"}, nil)
-	h.handleClear(ctx, tx, a1, 0)
+	h.handleClear(ctx, tx, a1)
 	assert.Equal(t, mockAlerts["existing_a1"].Status.String(), "ACTIVE")
 
 	// test alert clear - autoclear
 	mockAlerts["existing_a1"].AutoClear = true
-	h.handleClear(ctx, tx, a1, 0)
+	h.handleClear(ctx, tx, a1)
 	assert.Equal(t, mockAlerts["existing_a1"].Status.String(), "CLEARED")
 	event := <-h.procChan
 	assert.Equal(t, event.Type, models.EventType_CLEARED)
@@ -259,7 +262,7 @@ func TestHandlerAlertClear(t *testing.T) {
 	// test alert clear - ack'd
 	mockAlerts["existing_a3"].AutoClear = true
 	mockAlerts["existing_a3"].Owner.Valid = true
-	h.handleClear(ctx, tx, mockAlerts["existing_a3"], 0)
+	h.handleClear(ctx, tx, mockAlerts["existing_a3"])
 	assert.Equal(t, mockAlerts["existing_a3"].Status.String(), "ACTIVE")
 }
 

--- a/internal/models/alert.go
+++ b/internal/models/alert.go
@@ -41,8 +41,8 @@ var (
 	QuerySelectByAggId      = querySelectAlerts + " WHERE agg_id=$1"
 	QuerySelectByStatus     = querySelectAlerts + " WHERE status IN (?) ORDER BY id FOR UPDATE"
 	QuerySelectNoOwner      = querySelectAlerts + " WHERE owner is NULL AND status=1 ORDER BY id"
-	QuerySelectByNameEntity = querySelectAlerts + " WHERE name=$1 AND entity=$2 AND status=1 FOR UPDATE"
-	QuerySelectByDevice     = querySelectAlerts + " WHERE name=$1 AND entity=$2 AND device=$3 AND status=1 FOR UPDATE"
+	QuerySelectByNameEntity = querySelectAlerts + " WHERE name=$1 AND entity=$2 ORDER BY start_time DESC LIMIT 1 FOR UPDATE"
+	QuerySelectByDevice     = querySelectAlerts + " WHERE name=$1 AND entity=$2 AND device=$3 ORDER BY start_time DESC LIMIT 1 FOR UPDATE"
 	QuerySelectExistingAgg  = querySelectAlerts + " WHERE name=$1 AND entity=$2 AND device=$3 AND agg_id != 0 FOR UPDATE"
 	QuerySelectExpired      = querySelectAlerts + ` WHERE
     status=1 AND auto_expire AND (cast(extract(epoch from now()) as integer) - last_active) > expire_after ORDER BY id`

--- a/plugins/processors/aggregator/aggregator.go
+++ b/plugins/processors/aggregator/aggregator.go
@@ -183,6 +183,7 @@ func (a *Aggregator) checkExpired(ctx context.Context, out chan *models.AlertEve
 				}
 				a.statAggsActive.Add(-1)
 				tx.NewRecord(aggAlert.Id, fmt.Sprintf("Alert %s", status))
+				aggAlert.ExtendLabels()
 				out <- &models.AlertEvent{Alert: aggAlert, Type: models.EventMap[status]}
 			}
 		}

--- a/testutil/testdata/test_config.yaml
+++ b/testutil/testdata/test_config.yaml
@@ -35,7 +35,7 @@ alert_config:
 
   - name: Test Alert 3
     config:
-      clear_acknowledged: true
+      dont_clear_acknowledged: true
 
   - name: Neteng BGP Down
     config:


### PR DESCRIPTION
- this will create a single alert per incident. if an old cleared incident is refired, it will auto open the old alert and update its history. 
- this also means suppressed alerts are now cleared out when the issue clears, but can re-fire later after the suppression rule expires.