### PR TITLE
[UI] Add a banner warning/informing which alert DB is in use

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,69 +1,101 @@
-import React, { Component } from 'react';
-import { Router } from 'react-router';
-import {
-  Redirect,
-  Route,
-  Switch,
-} from 'react-router-dom';
-import PrivateRoute from './components/PrivateRoute/PrivateRoute'
-import createHistory from 'history/createBrowserHistory';
+import React, { Component } from "react";
+import { Router } from "react-router";
+import { Redirect, Route, Switch } from "react-router-dom";
+import PrivateRoute from "./components/PrivateRoute/PrivateRoute";
+import createHistory from "history/createBrowserHistory";
 
 /// ------------------------------------------------------
 /// Theme
 /// ------------------------------------------------------
-import { MuiThemeProvider } from '@material-ui/core/styles';
-import theme from './theme';
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import theme from "./theme";
 
 /// ------------------------------------------------------
 /// Views
 /// ------------------------------------------------------
-import HomeView from './views/HomeView';
-import OngoingAlertsView from './views/OngoingAlertsView';
-import AlertsExplorerView from'./views/AlertsExplorerView';
-import AlertView from './views/AlertView';
-import AlertsView from './views/AlertsView.js';
-import SuppressionRulesListView from './views/SuppRulesList';
+import HomeView from "./views/HomeView";
+import OngoingAlertsView from "./views/OngoingAlertsView";
+import AlertsExplorerView from "./views/AlertsExplorerView";
+import AlertView from "./views/AlertView";
+import AlertsView from "./views/AlertsView.js";
+import SuppressionRulesListView from "./views/SuppRulesList";
 
 /// ------------------------------------------------------
 /// Menu & Login page
 /// ------------------------------------------------------
-import SignIn from './components/SignIn/SignIn'
-import Header from './components/Header/Header';
-import { PagesDoc } from './static';
+import SignIn from "./components/SignIn/SignIn";
+import Header from "./components/Header/Header";
+import { PagesDoc } from "./static";
 
-import { AlertManagerApi } from './library/AlertManagerApi';
-import { NotificationProvider } from './components/contexts/NotificationContext';
+import Warning from "./library/envWarnings";
+import { AlertManagerApi } from "./library/AlertManagerApi";
+import { NotificationProvider } from "./components/contexts/NotificationContext";
 
-const history = createHistory();   
-const Auth = new AlertManagerApi()
+const history = createHistory();
+const Auth = new AlertManagerApi();
+const env = process.env;
+console.log("env: ", env);
 
 export default class App extends Component {
-  
   _redirectToHome() {
     return <Redirect to="/" />;
   }
 
   render() {
     return (
+      <>
+        <Warning {...env} />
+
         <Router history={history}>
           <MuiThemeProvider theme={theme}>
             <NotificationProvider>
-            <div>
-                <Header/>
+              <div>
+                <Header />
                 <Switch>
                   <Route exact path="/login" component={SignIn} />
-                  <PrivateRoute exact authed={Auth.checkToken()} path="/" component={AlertsView} />
-                  <PrivateRoute exact authed={Auth.checkToken()} path={PagesDoc.ongoingAlerts.url} component={OngoingAlertsView} />
-                  <PrivateRoute exact authed={Auth.checkToken()} path={PagesDoc.alerts.url} component={AlertsView} />
-                  <PrivateRoute exact authed={Auth.checkToken()} path={PagesDoc.alertsExplorer.url} component={AlertsExplorerView} />
-                  <PrivateRoute exact authed={Auth.checkToken()} path="/alert/:id/" component={AlertView} />
-                  <PrivateRoute exact authed={Auth.checkToken()} path={PagesDoc.suppressionRules.url} component={SuppressionRulesListView} />
+                  <PrivateRoute
+                    exact
+                    authed={Auth.checkToken()}
+                    path="/"
+                    component={AlertsView}
+                  />
+                  <PrivateRoute
+                    exact
+                    authed={Auth.checkToken()}
+                    path={PagesDoc.ongoingAlerts.url}
+                    component={OngoingAlertsView}
+                  />
+                  <PrivateRoute
+                    exact
+                    authed={Auth.checkToken()}
+                    path={PagesDoc.alerts.url}
+                    component={AlertsView}
+                  />
+                  <PrivateRoute
+                    exact
+                    authed={Auth.checkToken()}
+                    path={PagesDoc.alertsExplorer.url}
+                    component={AlertsExplorerView}
+                  />
+                  <PrivateRoute
+                    exact
+                    authed={Auth.checkToken()}
+                    path="/alert/:id/"
+                    component={AlertView}
+                  />
+                  <PrivateRoute
+                    exact
+                    authed={Auth.checkToken()}
+                    path={PagesDoc.suppressionRules.url}
+                    component={SuppressionRulesListView}
+                  />
                   <Route render={this._redirectToHome} />
                 </Switch>
-            </div>
+              </div>
             </NotificationProvider>
           </MuiThemeProvider>
         </Router>
+      </>
     );
   }
 }

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -34,7 +34,6 @@ import { NotificationProvider } from "./components/contexts/NotificationContext"
 const history = createHistory();
 const Auth = new AlertManagerApi();
 const env = process.env;
-console.log("env: ", env);
 
 export default class App extends Component {
   _redirectToHome() {

--- a/ui/src/library/envWarnings.js
+++ b/ui/src/library/envWarnings.js
@@ -1,13 +1,13 @@
 import React from "react";
-import { CRITICAL, WARN } from "../styles/styles";
+import { CRITICAL, PRIMARY, WARN } from "../styles/styles";
 import styled from "styled-components";
 
 const WarningBanner = styled.div`
   position: sticky;
   top: 0;
-  background-color: ${props => (props.bgColor ? props.bgColor : WARN)};
-  color: null;
-  padding: 1em;
+  background-color: ${props => (props.critical ? CRITICAL : WARN)};
+  color: ${PRIMARY};
+  padding: 0.6em;
   text-align: center;
   z-index: 10;
 
@@ -33,17 +33,24 @@ export default function Warning({ NODE_ENV, REACT_APP_ALERT_MANAGER_SERVER }) {
   const integrationEnv =
     window.location.origin === ALERT_MANAGER_INTEGRATION_SERVER;
 
-  const warnMsg = (
-    <p>
-      <strong>!!WARNING!! Using Production Alert Database.</strong> Proceed with
-      caution. Changes will affect our production alerts.
-    </p>
+  const criticalMsg = (
+    <>
+      <p>
+        <strong>!! WARNING !! Using Production Alert Database.</strong>
+      </p>
+      <p>Proceed with caution. Changes will affect our production alerts.</p>
+    </>
   );
-  const infoMsg = (
-    <p>
-      <strong>Using Test Alert Database.</strong> These alerts may not match{" "}
-      <strong>production</strong> alerts and may include test data.
-    </p>
+  const warnMsg = (
+    <>
+      <p>
+        <strong>Using Test Alert Database.</strong>
+      </p>
+      <p>
+        These alerts may not match <strong>production</strong> alerts and may
+        include test data.
+      </p>
+    </>
   );
 
   /* Different Scenarios We Warn For
@@ -55,13 +62,13 @@ export default function Warning({ NODE_ENV, REACT_APP_ALERT_MANAGER_SERVER }) {
       - WARN: When using Integration Server with PROD Backend (This should never happen) */
   let warning = null;
   if (!deployedNodeEnv && prodBackend) {
-    warning = <WarningBanner bgColor={CRITICAL}>{warnMsg}</WarningBanner>;
+    warning = <WarningBanner critical>{criticalMsg}</WarningBanner>;
   } else if (!deployedNodeEnv && !prodBackend) {
-    warning = <WarningBanner>{infoMsg}</WarningBanner>;
+    warning = <WarningBanner>{warnMsg}</WarningBanner>;
   } else if (deployedNodeEnv && !prodBackend) {
-    warning = <WarningBanner>{infoMsg}</WarningBanner>;
+    warning = <WarningBanner>{warnMsg}</WarningBanner>;
   } else if (integrationEnv && prodBackend) {
-    warning = <WarningBanner bgColor={CRITICAL}>{warnMsg}</WarningBanner>;
+    warning = <WarningBanner critical>{criticalMsg}</WarningBanner>;
   }
 
   return warning;

--- a/ui/src/library/envWarnings.js
+++ b/ui/src/library/envWarnings.js
@@ -17,16 +17,21 @@ const WarningBanner = styled.div`
   }
 `;
 
-const ALERT_MANAGER_SERVER = {
+const ALERT_MANAGER_API = {
   prod: "https://alert-manager-api.simulprod.com/",
   integration: "https://alert-manager-integration-api.simulprod.com/"
 };
+
+const ALERT_MANAGER_INTEGRATION_SERVER =
+  "https://alert-manager-integration.simulprod.com";
 
 export default function Warning({ NODE_ENV, REACT_APP_ALERT_MANAGER_SERVER }) {
   // Integration and Production deployments have "production" versions of node
   const deployedNodeEnv = NODE_ENV === "production" ? true : false;
   const prodBackend =
-    REACT_APP_ALERT_MANAGER_SERVER === ALERT_MANAGER_SERVER.prod ? true : false;
+    REACT_APP_ALERT_MANAGER_SERVER === ALERT_MANAGER_API.prod ? true : false;
+  const integrationEnv =
+    window.location.origin === ALERT_MANAGER_INTEGRATION_SERVER;
 
   const warnMsg = (
     <p>
@@ -46,7 +51,8 @@ export default function Warning({ NODE_ENV, REACT_APP_ALERT_MANAGER_SERVER }) {
       - INFORM: When using the test (integration) backend
       - WARN: When using PROD alert backend
     2. Production (Integration and Production Deployments)
-      - INFORM: WHen using the test (integration) backend */
+      - INFORM: WHen using the test (integration) backend 
+      - WARN: When using Integration Server with PROD Backend (This should never happen) */
   let warning = null;
   if (!deployedNodeEnv && prodBackend) {
     warning = <WarningBanner bgColor={CRITICAL}>{warnMsg}</WarningBanner>;
@@ -54,6 +60,8 @@ export default function Warning({ NODE_ENV, REACT_APP_ALERT_MANAGER_SERVER }) {
     warning = <WarningBanner>{infoMsg}</WarningBanner>;
   } else if (deployedNodeEnv && !prodBackend) {
     warning = <WarningBanner>{infoMsg}</WarningBanner>;
+  } else if (integrationEnv && prodBackend) {
+    warning = <WarningBanner bgColor={CRITICAL}>{warnMsg}</WarningBanner>;
   }
 
   return warning;

--- a/ui/src/library/envWarnings.js
+++ b/ui/src/library/envWarnings.js
@@ -1,0 +1,60 @@
+import React from "react";
+import { CRITICAL, WARN } from "../styles/styles";
+import styled from "styled-components";
+
+const WarningBanner = styled.div`
+  position: sticky;
+  top: 0;
+  background-color: ${props => (props.bgColor ? props.bgColor : WARN)};
+  color: null;
+  padding: 1em;
+  text-align: center;
+  z-index: 10;
+
+  p {
+    padding: 0;
+    margin: 0;
+  }
+`;
+
+const ALERT_MANAGER_SERVER = {
+  prod: "https://alert-manager-api.simulprod.com/",
+  integration: "https://alert-manager-integration-api.simulprod.com/"
+};
+
+export default function Warning({ NODE_ENV, REACT_APP_ALERT_MANAGER_SERVER }) {
+  // Integration and Production deployments have "production" versions of node
+  const deployedNodeEnv = NODE_ENV === "production" ? true : false;
+  const prodBackend =
+    REACT_APP_ALERT_MANAGER_SERVER === ALERT_MANAGER_SERVER.prod ? true : false;
+
+  const warnMsg = (
+    <p>
+      <strong>!!WARNING!! Using Production Alert Database.</strong> Proceed with
+      caution. Changes will affect our production alerts.
+    </p>
+  );
+  const infoMsg = (
+    <p>
+      <strong>Using Test Alert Database.</strong> These alerts may not match{" "}
+      <strong>production</strong> alerts and may include test data.
+    </p>
+  );
+
+  /* Different Scenarios We Warn For
+    1. Local Development: 
+      - INFORM: When using the test (integration) backend
+      - WARN: When using PROD alert backend
+    2. Production (Integration and Production Deployments)
+      - INFORM: WHen using the test (integration) backend */
+  let warning = null;
+  if (!deployedNodeEnv && prodBackend) {
+    warning = <WarningBanner bgColor={CRITICAL}>{warnMsg}</WarningBanner>;
+  } else if (!deployedNodeEnv && !prodBackend) {
+    warning = <WarningBanner>{infoMsg}</WarningBanner>;
+  } else if (deployedNodeEnv && !prodBackend) {
+    warning = <WarningBanner>{infoMsg}</WarningBanner>;
+  }
+
+  return warning;
+}


### PR DESCRIPTION
The banner will display the following: 
    1. Local Development: 
      - INFORM: When using the test (integration) backend
      - WARN: When using PROD alert backend
    2. Production (Integration and Production Deployments)
      - INFORM: When using the test (integration) backend 
      - WARN: When using Integration Server with PROD Backend (This should never happen)

## Local Development with PROD alert DB
![CleanShot 2019-09-26 at 12 02 43](https://user-images.githubusercontent.com/3409857/65705286-21c6d980-e056-11e9-9fa7-b7423a3f8174.png)

## Local Development with Integration (test) alert DB
![CleanShot 2019-09-26 at 12 01 10](https://user-images.githubusercontent.com/3409857/65705319-31deb900-e056-11e9-9081-69bea285deb0.png)

## Deployment (Prod and Integration) with PROD alert DB
![CleanShot 2019-09-26 at 11 58 05](https://user-images.githubusercontent.com/3409857/65705419-6783a200-e056-11e9-8185-f7d0c617f6c5.png)

## Deployment (Prod and Integration) with Integration (test) alert DB
![CleanShot 2019-09-26 at 11 58 40](https://user-images.githubusercontent.com/3409857/65705464-808c5300-e056-11e9-95f7-1466194da8b0.png)
