### PR TITLE
Fix goroutine leak due to unclosed txns

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -236,8 +236,11 @@ func (s *Server) CreateToken(w http.ResponseWriter, req *http.Request) {
 	glog.V(2).Infof("Successfully authenticated user: %s", user.Username)
 
 	tx := s.handler.Db.NewTx()
-	dbUser, err := tx.GetUser(claims.Username)
-	if err != nil {
+	var dbUser models.User
+	if err = models.WithTx(req.Context(), tx, func(ctx context.Context, tx models.Txn) error {
+		dbUser, err = tx.GetUser(claims.Username)
+		return err
+	}); err != nil {
 		http.Error(w, fmt.Sprintf("Unable to find user in database: %v", err), http.StatusBadRequest)
 		return
 	}
@@ -266,8 +269,11 @@ func (s *Server) RefreshToken(w http.ResponseWriter, req *http.Request) {
 	glog.V(2).Infof("Successfully renewed claims for user: %s", claims.Username)
 
 	tx := s.handler.Db.NewTx()
-	dbUser, err := tx.GetUser(claims.Username)
-	if err != nil {
+	var dbUser models.User
+	if err = models.WithTx(req.Context(), tx, func(ctx context.Context, tx models.Txn) error {
+		dbUser, err = tx.GetUser(claims.Username)
+		return err
+	}); err != nil {
 		http.Error(w, fmt.Sprintf("Unable to find user in database: %v", err), http.StatusBadRequest)
 		return
 	}

--- a/listener/webhook.go
+++ b/listener/webhook.go
@@ -232,7 +232,7 @@ func (k *WebHookListener) Uri() string {
 func (k WebHookListener) Listen(ctx context.Context) {
 	http.HandleFunc("/listener/alert/", k.basicAuth(k.httpHandler))
 	http.HandleFunc("/listener/ping/", k.pingHandler)
-	srv := &http.Server{Addr: k.ListenAddr}
+	srv := &http.Server{Addr: k.ListenAddr, ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second}
 	idleConnsClosed := make(chan struct{})
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION
fix unclosed txns in createToken and refreshToken causing goroutine leaks. Also add sane timeouts for webhook server